### PR TITLE
Slight optimizations 

### DIFF
--- a/src/Services/AspNetCoreTemplate.Services.Data/SettingsService.cs
+++ b/src/Services/AspNetCoreTemplate.Services.Data/SettingsService.cs
@@ -18,7 +18,7 @@
 
         public int GetCount()
         {
-            return this.settingsRepository.All().Count();
+            return this.settingsRepository.AllAsNoTracking().Count();
         }
 
         public IEnumerable<T> GetAll<T>()

--- a/src/Tests/AspNetCoreTemplate.Services.Data.Tests/SettingsServiceTests.cs
+++ b/src/Tests/AspNetCoreTemplate.Services.Data.Tests/SettingsServiceTests.cs
@@ -37,7 +37,7 @@
         {
             var options = new DbContextOptionsBuilder<ApplicationDbContext>()
                 .UseInMemoryDatabase(databaseName: "SettingsTestDb").Options;
-            var dbContext = new ApplicationDbContext(options);
+            using var dbContext = new ApplicationDbContext(options);
             dbContext.Settings.Add(new Setting());
             dbContext.Settings.Add(new Setting());
             dbContext.Settings.Add(new Setting());

--- a/src/Tests/AspNetCoreTemplate.Services.Data.Tests/SettingsServiceTests.cs
+++ b/src/Tests/AspNetCoreTemplate.Services.Data.Tests/SettingsServiceTests.cs
@@ -43,7 +43,7 @@
             dbContext.Settings.Add(new Setting());
             await dbContext.SaveChangesAsync();
 
-            var repository = new EfDeletableEntityRepository<Setting>(dbContext);
+            using var repository = new EfDeletableEntityRepository<Setting>(dbContext);
             var service = new SettingsService(repository);
             Assert.Equal(3, service.GetCount());
         }


### PR DESCRIPTION
- Adding the ''using'' keyword to handle the IDisposable ApplicationDbContext & EfDeletableEntityRepository

- Using the .AllAsNoTracking() repository method for when getting the settings count (as it's a read only operation)


