### PR TITLE
Fix bug with renaming file contents method

### DIFF
--- a/tools/TemplateRenamer/Program.cs
+++ b/tools/TemplateRenamer/Program.cs
@@ -88,7 +88,7 @@
             var files = Directory.GetFiles(currentDirectory);
             foreach (var file in files)
             {
-                if (!file.EndsWith(".exe") && !file.EndsWith(".dll"))
+                if (!file.EndsWith(".exe") && !file.EndsWith(".dll") && !file.EndsWith(".runtimeconfig.json"))
                 {
                     var contents = File.ReadAllText(file);
                     contents = contents.Replace(originalName, newName);


### PR DESCRIPTION
I have found a bug when using the Template Renamer tool, which occurs when .exe, .dll and .runtimeconfig.dev.json are put in the main directory of ASP.NET Core app. All the files are required in order to run the .exe. After that I debugged and saw the .runtimeconfig.dev.json in not omitted, so the Renamer tries to change the content of this file which is already used by it. To fix that I added that case in the if clause so the renamer works correctly now. As an advice, it should be great if erros are proccessed with simple try-catch block in order to save time while searching for the bug.