### PR TITLE
Add check allowing entity inheritance

### DIFF
--- a/src/Data/AspNetCoreTemplate.Data/ApplicationDbContext.cs
+++ b/src/Data/AspNetCoreTemplate.Data/ApplicationDbContext.cs
@@ -58,7 +58,7 @@
 
             // Set global query filter for not deleted entities only
             var deletableEntityTypes = entityTypes
-                .Where(et => et.ClrType != null && typeof(IDeletableEntity).IsAssignableFrom(et.ClrType));
+                .Where(et => et.ClrType != null && typeof(IDeletableEntity).IsAssignableFrom(et.ClrType) && et.BaseType == null);
             foreach (var deletableEntityType in deletableEntityTypes)
             {
                 var method = SetIsDeletedQueryFilterMethod.MakeGenericMethod(deletableEntityType.ClrType);


### PR DESCRIPTION
If we have instances were entities are inheriting from such which have the IDeletable filter, we will get an exception :
> The filter expression cannot be specified for entity type. A filter may only be applied to the root entity type in a hierarchy

_(more on that here: https://entityframeworkcore.com/knowledge-base/60794584/the-filter-expression-cannot-be-specified-for-entity-type--a-filter-may-only-be-applied-to-the-root-entity-type-in-a-hierarchy)_ 

Reasoning being of the difference between base class and base entity: https://stackoverflow.com/a/56407939 
_(I'm not associated with the one who gave the answer. Nonetheless good job, Ivan!)_

This exception might be expected behavior, as it can point to DB normalization issues. 
If so, please reject the PR. 

Muchas Gracias, 
