### PR TITLE
Removed unnecessary query filtering

### DIFF
--- a/src/Data/AspNetCoreTemplate.Data/Repositories/EfDeletableEntityRepository.cs
+++ b/src/Data/AspNetCoreTemplate.Data/Repositories/EfDeletableEntityRepository.cs
@@ -16,8 +16,6 @@
         {
         }
 
-        public override IQueryable<TEntity> All() => base.All().Where(x => !x.IsDeleted);
-
         public override IQueryable<TEntity> AllAsNoTracking() => base.AllAsNoTracking().Where(x => !x.IsDeleted);
 
         public IQueryable<TEntity> AllWithDeleted() => base.All().IgnoreQueryFilters();


### PR DESCRIPTION
Removed unnecessary query filtering in the EfDeletableEntityRepository.cs There is no need to additional query the collection with (x => !x.IsDeleted) because the class constraint is IDeletableEntity which already has global query filter for that because of this the SQL query looks like ([t].[IsDeleted] = CAST(0 AS bit)) AND ([t].[IsDeleted] = CAST(0 AS bit)) which doesn't make sense