### PR TITLE
Add Microsoft.EntityFrameworkCore.Design to Web project

### DIFF
--- a/src/Web/AspNetCoreTemplate.Web/AspNetCoreTemplate.Web.csproj
+++ b/src/Web/AspNetCoreTemplate.Web/AspNetCoreTemplate.Web.csproj
@@ -18,6 +18,10 @@
 	</ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.3" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />


### PR DESCRIPTION
@NikolayIT, I found out that when using Migrations for the first time the **AspNetCoreTemplate.Web** project does not have reference to Microsoft.EntityFrameworkCore.Design so that an error is thrown in the PM console. I think it will be better if the Web project has that dependency already installed. Currently, the latest stable version is 7.0.5, but I added 7.0.3 since the other packages are not yet updated. I am attaching also an image of the initial error when the template is used for the first time for new project:
![error-in-web](https://user-images.githubusercontent.com/45464117/233202951-127df901-5e05-49c7-afe4-53d7e745b249.jpg)
